### PR TITLE
feat(mcp): expand MCP toolset (read tools + git write tools with merge threshold)

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -31,9 +31,46 @@ npx -y @worktree-manager/mcp install
 npx -y @worktree-manager/mcp uninstall
 ```
 
+## Capability Levels
+
+Tools are grouped into three capability levels. The default level is **`details`** (all read tools enabled). Write tools require explicit opt-in to `advanced`.
+
+| Level | What's available | Requires |
+|-------|-----------------|----------|
+| `core` | Basic workspace/worktree read tools (stdio or HTTP) | Always available |
+| `details` | All core tools + project/branch read tools | HTTP transport (Worktree Manager app running) |
+| `advanced` | All of the above + write/git tools | HTTP transport + explicit user opt-in |
+
+### Changing the Capability Level
+
+**Option A — Edit the config file directly:**
+
+```json
+// ~/.config/worktree-manager/mcp.json
+{
+  "capability_level": "advanced"
+}
+```
+
+Valid values: `"core"`, `"details"`, `"advanced"`. The server reads this file on startup; restart the MCP server after editing.
+
+**Option B — Via the Worktree Manager desktop app:**
+
+Call the REST endpoint while the app is running:
+
+```bash
+curl -X POST http://127.0.0.1:42819/api/mcp/set_capability \
+  -H 'Content-Type: application/json' \
+  -d '{"capability_level": "advanced"}'
+```
+
+> The capability setting is **preserved** across desktop app restarts and MCP server reinstalls — it is never silently reset.
+
 ## Available Tools
 
 ### Layer 1 — Core (Always Available)
+
+Available with any transport (stdio fallback or HTTP). No special configuration needed.
 
 | Tool | Description |
 |------|-------------|
@@ -42,23 +79,155 @@ npx -y @worktree-manager/mcp uninstall
 | `worktree_list` | List all worktrees in current workspace |
 | `worktree_get_status` | Get detailed status of a specific worktree |
 | `workspace_get_status` | Get main workspace status |
+| `get_active_workspace` | Resolve which workspace/worktree/project the current directory belongs to |
 
-### Layer 2 — Details (On Demand)
+#### `get_active_workspace` — Usage Notes
+
+The caller **must** pass the current absolute working directory as `cwd`. The server has no session context and cannot infer it automatically.
+
+```json
+{ "cwd": "/Users/you/work/my-workspace/worktrees/feature-42/projects/api" }
+```
+
+Returns:
+```json
+{
+  "workspace": { "name": "my-workspace", "path": "/Users/you/work/my-workspace" },
+  "worktree_name": "feature-42",
+  "project_name": "api",
+  "matched_by": "prefix"
+}
+```
+
+Returns `null` fields when the directory is not inside any configured workspace.
+
+---
+
+### Layer 2 — Details (Requires HTTP Transport)
+
+Requires the Worktree Manager desktop app to be running (`capability_level` = `details` or `advanced`).
 
 | Tool | Description |
 |------|-------------|
-| `project_get_branches` | Get list of branches for a project |
+| `project_get_branches` | List remote branches for a project |
 | `project_get_diff_stats` | Get diff statistics vs base branch |
-| `project_get_changed_files` | List uncommitted files |
+| `project_get_changed_files` | List uncommitted files in a project |
+| `list_projects` | List projects (with branch info) across all worktrees, optionally filtered by worktree name |
+| `get_branch_status` | Get ahead/behind/changed-file count for a project branch |
 
-### Layer 3 — Advanced (Wrapped by Skills)
+#### `get_branch_status` — Return Shape
+
+```json
+{
+  "ahead": 3,
+  "behind": 0,
+  "changed_files": 1,
+  "unpushed_commits": 3,
+  "ahead_of_test": 2
+}
+```
+
+- `ahead` / `behind`: commits relative to `origin/<base_branch>`
+- `ahead_of_test`: commits ahead of the test branch (requires `test_branch` parameter)
+- `changed_files`: uncommitted working-tree changes
+- Data is computed from **local git references** — pass `fetch_first: true` to refresh from remote first
+
+```json
+{
+  "project_path": "/abs/path/to/project",
+  "base_branch": "main",
+  "test_branch": "test",
+  "fetch_first": true
+}
+```
+
+---
+
+### Layer 3 — Advanced (Requires HTTP Transport + `capability_level: advanced`)
+
+Write tools that can trigger destructive git operations. See the [Trust Boundary](#trust-boundary) section below before enabling.
 
 | Tool | Description |
 |------|-------------|
-| `worktree_create` | Create a new worktree |
+| `worktree_create` | Create a new worktree with specified projects |
 | `worktree_archive` | Archive an existing worktree |
-| `git_commit` | Stage and commit changes |
-| `git_push` | Push to remote |
+| `worktree_delete_archived` | Permanently delete an archived worktree |
+| `git_commit` | Stage all changes and commit with a message |
+| `git_push` | Push current branch to remote |
+| `git_switch_branch` | Switch to a different branch |
+| `git_fetch` | Fetch from remote origin |
+| `sync_base` | Sync the latest base branch into the current branch (fetch + merge) |
+| `pull` | `git pull` the current branch from origin |
+| `push` | Push the current branch to origin |
+| `commit_and_push` | Stage, commit, then push in one step (non-atomic — see note) |
+| `merge_to_test` | Merge current branch into the test branch (guarded by threshold) |
+| `merge_to_base` | Merge current branch into the base branch (guarded by threshold) |
+
+#### `commit_and_push` — Non-Atomic Behavior
+
+If the commit succeeds but the push fails, the tool returns `isError: true` with a "committed but not pushed" message. The commit is **not** rolled back. You can then call `push` separately.
+
+---
+
+## Merge Threshold Gate
+
+`merge_to_test` and `merge_to_base` include a safety gate to prevent accidental large merges.
+
+### Default Thresholds
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `max_ahead` | `50` | Maximum commits ahead of the target branch allowed |
+| `require_clean_worktree` | `true` | Block merge if there are uncommitted changes |
+| `force` | `false` | Bypass all threshold checks when set to `true` |
+
+### Per-Call Override
+
+Thresholds are **not** persisted — pass them as arguments each time:
+
+```json
+{
+  "project_path": "/abs/path/to/project",
+  "base_branch": "main",
+  "test_branch": "test",
+  "max_ahead": 100,
+  "require_clean_worktree": false
+}
+```
+
+### Measurement
+
+- `merge_to_test`: the `ahead_of_test` field from `get_branch_status` is used as the "ahead" count
+- `merge_to_base`: the `ahead` field (commits ahead of `origin/<base_branch>`) is used
+
+### Bypassing the Gate
+
+Pass `force: true` to skip all checks:
+
+```json
+{ "project_path": "...", "base_branch": "main", "test_branch": "test", "force": true }
+```
+
+> Note: The threshold gate is enforced in the MCP layer only. Calling the backend REST API directly bypasses it.
+
+---
+
+## Trust Boundary
+
+> **Warning: No token authentication on the backend port.**
+
+The MCP data backend runs at `127.0.0.1:42819` and is **bound to localhost with no token authentication**. Any process running on your machine can call it directly.
+
+**Trust boundary = all local processes on your machine.**
+
+This is an intentional design choice for local developer tooling. The practical implications:
+
+- `details` (read tools): low risk — read-only data, no state changes
+- `advanced` (write tools): can trigger git commits, pushes, branch switches, and merges
+
+**Only set `capability_level: advanced` in trusted, single-user local environments.** Do not expose port 42819 to a network or run with `advanced` capability on shared machines.
+
+---
 
 ## How It Works
 
@@ -67,8 +236,10 @@ Claude Code/Codex ←→ MCP Protocol ←→ @worktree-manager/mcp ←→ Worktr
                               (HTTP:42819)
 ```
 
-When Worktree Manager desktop app is running → real-time data via HTTP.
-When app is not running → reads from config file fallback.
+When Worktree Manager desktop app is running → real-time data via HTTP (details + advanced tools available).
+When app is not running → reads from config file fallback (core tools only, no write tools).
+
+---
 
 ## Requirements
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -12,6 +12,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "test": "tsc && node --test dist/tools/safety.test.js",
     "prepublish": "npm run build"
   },
   "dependencies": {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -62,11 +62,21 @@ function writeMcpConfig(): void {
     if (!existsSync(dir)) {
       mkdirSync(dir, { recursive: true });
     }
+    // 保留已有 capability_level（用户或桌面端设置过的），缺省 details
+    let capabilityLevel = 'details';
+    try {
+      if (existsSync(MCP_CONFIG_PATH)) {
+        const existing = JSON.parse(readFileSync(MCP_CONFIG_PATH, 'utf-8'));
+        if (['core', 'details', 'advanced'].includes(existing?.capability_level)) {
+          capabilityLevel = existing.capability_level;
+        }
+      }
+    } catch {}
     const mcpConfig = {
       version: '1.0.0',
       http_port: 42819,
       installed_at: new Date().toISOString(),
-      capability_level: 'core',
+      capability_level: capabilityLevel,
     };
     writeFileSync(MCP_CONFIG_PATH, JSON.stringify(mcpConfig, null, 2));
   } catch (e) {

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -1,6 +1,6 @@
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { ListToolsRequestSchema, CallToolRequestSchema, type CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { ListToolsRequestSchema, CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { HttpTransport } from './transport/http.js';
 import { ConfigTransport } from './transport/config.js';
 import { buildCoreHandlers, CORE_TOOLS } from './tools/core.js';
@@ -74,11 +74,11 @@ export class WorktreeMcpServer {
     this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
       const { name, arguments: args } = request.params;
       const handler = this.handlers[name];
-      if (!handler) return errorResult(`Unknown tool: ${name}`) as unknown as CallToolResult;
+      if (!handler) return errorResult(`Unknown tool: ${name}`);
       try {
-        return await handler((args ?? {}) as Record<string, unknown>) as unknown as CallToolResult;
+        return await handler((args ?? {}) as Record<string, unknown>);
       } catch (e) {
-        return errorResult(`Error: ${e instanceof Error ? e.message : String(e)}`) as unknown as CallToolResult;
+        return errorResult(`Error: ${e instanceof Error ? e.message : String(e)}`);
       }
     });
 

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -8,6 +8,9 @@ import { buildDetailsHandlers, DETAILS_TOOLS } from './tools/details.js';
 import { buildAdvancedHandlers, ADVANCED_TOOLS } from './tools/advanced.js';
 import { type ToolHandler, errorResult } from './tools/shared.js';
 import type { CapabilityLevel } from './types.js';
+import { readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
 
 export class WorktreeMcpServer {
   private server: Server | null = null;
@@ -47,8 +50,23 @@ export class WorktreeMcpServer {
       }
     );
 
+    // 读取 mcp.json 的 capability_level（缺省 details）
+    this.capabilityLevel = this.loadCapabilityLevel();
+
     // Register tools based on capability level
     this.registerTools();
+  }
+
+  private loadCapabilityLevel(): CapabilityLevel {
+    try {
+      const p = join(homedir(), '.config', 'worktree-manager', 'mcp.json');
+      if (existsSync(p)) {
+        const cfg = JSON.parse(readFileSync(p, 'utf-8'));
+        const lvl = cfg?.capability_level;
+        if (lvl === 'core' || lvl === 'details' || lvl === 'advanced') return lvl;
+      }
+    } catch {}
+    return 'details';
   }
 
   private registerTools(): void {

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -1,17 +1,19 @@
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { ListToolsRequestSchema, CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import { ListToolsRequestSchema, CallToolRequestSchema, type CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { HttpTransport } from './transport/http.js';
 import { ConfigTransport } from './transport/config.js';
-import { registerCoreTools, CORE_TOOLS } from './tools/core.js';
-import { registerDetailsTools, DETAILS_TOOLS } from './tools/details.js';
-import { registerAdvancedTools, ADVANCED_TOOLS } from './tools/advanced.js';
+import { buildCoreHandlers, CORE_TOOLS } from './tools/core.js';
+import { buildDetailsHandlers, DETAILS_TOOLS } from './tools/details.js';
+import { buildAdvancedHandlers, ADVANCED_TOOLS } from './tools/advanced.js';
+import { type ToolHandler, errorResult } from './tools/shared.js';
 import type { CapabilityLevel } from './types.js';
 
 export class WorktreeMcpServer {
   private server: Server | null = null;
   private transport: HttpTransport | ConfigTransport | null = null;
   private capabilityLevel: CapabilityLevel = 'core';
+  private handlers: Record<string, ToolHandler> = {};
 
   constructor() {}
 
@@ -51,44 +53,37 @@ export class WorktreeMcpServer {
 
   private registerTools(): void {
     if (!this.server || !this.transport) return;
-
     const transport = this.transport;
+    const httpOnly = transport instanceof HttpTransport;
 
-    // Core tools always registered
-    registerCoreTools(this.server, transport);
+    // 按 capability + transport 聚合 handler map（高层覆盖不再丢失低层）
+    let handlers: Record<string, ToolHandler> = { ...buildCoreHandlers(transport) };
+    let tools: any[] = [...CORE_TOOLS];
 
-    // Details tools - only available with HTTP transport
-    if (this.capabilityLevel === 'details' || this.capabilityLevel === 'advanced') {
-      if (transport instanceof HttpTransport) {
-        registerDetailsTools(this.server, transport);
-      }
+    if ((this.capabilityLevel === 'details' || this.capabilityLevel === 'advanced') && httpOnly) {
+      handlers = { ...handlers, ...buildDetailsHandlers(transport) };
+      tools = tools.concat(DETAILS_TOOLS);
     }
-
-    // Advanced tools - only available with HTTP transport
-    if (this.capabilityLevel === 'advanced') {
-      if (transport instanceof HttpTransport) {
-        registerAdvancedTools(this.server, transport);
-      }
+    if (this.capabilityLevel === 'advanced' && httpOnly) {
+      handlers = { ...handlers, ...buildAdvancedHandlers(transport) };
+      tools = tools.concat(ADVANCED_TOOLS);
     }
+    this.handlers = handlers;
 
-    // Set tool list handler
-    this.server.setRequestHandler(
-      ListToolsRequestSchema,
-      async () => {
-        let tools: any[] = [...CORE_TOOLS];
-        if (this.capabilityLevel === 'details' || this.capabilityLevel === 'advanced') {
-          if (transport instanceof HttpTransport) {
-            tools = tools.concat(DETAILS_TOOLS);
-          }
-        }
-        if (this.capabilityLevel === 'advanced') {
-          if (transport instanceof HttpTransport) {
-            tools = tools.concat(ADVANCED_TOOLS);
-          }
-        }
-        return { tools };
+    // 单一 CallTool dispatcher
+    this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
+      const { name, arguments: args } = request.params;
+      const handler = this.handlers[name];
+      if (!handler) return errorResult(`Unknown tool: ${name}`) as unknown as CallToolResult;
+      try {
+        return await handler((args ?? {}) as Record<string, unknown>) as unknown as CallToolResult;
+      } catch (e) {
+        return errorResult(`Error: ${e instanceof Error ? e.message : String(e)}`) as unknown as CallToolResult;
       }
-    );
+    });
+
+    // 单一 ListTools
+    this.server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools }));
   }
 
   setCapabilityLevel(level: CapabilityLevel): void {

--- a/packages/mcp/src/tools/advanced.ts
+++ b/packages/mcp/src/tools/advanced.ts
@@ -1,5 +1,7 @@
 import type { Transport } from '../transport/http.js';
 import { type ToolHandler, textResult } from './shared.js';
+import { evaluateMergeGate, gateOptsFromArgs } from './safety.js';
+import type { BranchDiffStats } from '../types.js';
 
 export function buildAdvancedHandlers(transport: Transport): Record<string, ToolHandler> {
   return {
@@ -90,6 +92,35 @@ export function buildAdvancedHandlers(transport: Transport): Record<string, Tool
           isError: true,
         };
       }
+    },
+
+    merge_to_test: async (args) => {
+      const projectPath = args?.project_path as string;
+      const baseBranch = args?.base_branch as string;
+      const testBranch = args?.test_branch as string;
+      if (!projectPath || !baseBranch || !testBranch) {
+        throw new Error('project_path, base_branch and test_branch are required');
+      }
+      const stats = (await transport.getBranchDiffStats(projectPath, baseBranch, testBranch)) as BranchDiffStats;
+      const gate = evaluateMergeGate(
+        { ahead: stats.ahead_of_test, changed_files: stats.changed_files },
+        gateOptsFromArgs(args)
+      );
+      if (!gate.allow) return { content: [{ type: 'text', text: `合并到 test 被拦截：${gate.reason}` }], isError: true };
+      return textResult(await transport.mergeToTest(projectPath, testBranch));
+    },
+
+    merge_to_base: async (args) => {
+      const projectPath = args?.project_path as string;
+      const baseBranch = args?.base_branch as string;
+      if (!projectPath || !baseBranch) throw new Error('project_path and base_branch are required');
+      const stats = (await transport.getBranchDiffStats(projectPath, baseBranch)) as BranchDiffStats;
+      const gate = evaluateMergeGate(
+        { ahead: stats.ahead, changed_files: stats.changed_files },
+        gateOptsFromArgs(args)
+      );
+      if (!gate.allow) return { content: [{ type: 'text', text: `合并到 base 被拦截：${gate.reason}` }], isError: true };
+      return textResult(await transport.mergeToBase(projectPath, baseBranch));
     },
   };
 }
@@ -229,6 +260,37 @@ export const ADVANCED_TOOLS = [
         skip_hooks: { type: 'boolean' },
       },
       required: ['project_path', 'message'],
+    },
+  },
+  {
+    name: 'merge_to_test',
+    description: 'Merge the current branch into the test branch, guarded by a "not too many commits" threshold. Blocks if ahead_of_test > max_ahead (default 50) or worktree is dirty, unless force:true. Requires advanced capability.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        project_path: { type: 'string' },
+        base_branch: { type: 'string', description: 'Needed to compute ahead/behind stats' },
+        test_branch: { type: 'string' },
+        max_ahead: { type: 'number', description: 'Max commits ahead of test allowed (default 50)' },
+        require_clean_worktree: { type: 'boolean', description: 'Block if uncommitted changes (default true)' },
+        force: { type: 'boolean', description: 'Bypass all guards' },
+      },
+      required: ['project_path', 'base_branch', 'test_branch'],
+    },
+  },
+  {
+    name: 'merge_to_base',
+    description: 'Merge the current branch into the base branch, guarded by a "not too many commits" threshold. Blocks if ahead (of base) > max_ahead (default 50) or worktree is dirty, unless force:true. Requires advanced capability.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        project_path: { type: 'string' },
+        base_branch: { type: 'string' },
+        max_ahead: { type: 'number', description: 'Max commits ahead of base allowed (default 50)' },
+        require_clean_worktree: { type: 'boolean', description: 'Block if uncommitted changes (default true)' },
+        force: { type: 'boolean', description: 'Bypass all guards' },
+      },
+      required: ['project_path', 'base_branch'],
     },
   },
 ];

--- a/packages/mcp/src/tools/advanced.ts
+++ b/packages/mcp/src/tools/advanced.ts
@@ -1,5 +1,5 @@
 import type { Transport } from '../transport/http.js';
-import { type ToolHandler, textResult } from './shared.js';
+import { type ToolHandler, textResult, errorResult } from './shared.js';
 import { evaluateMergeGate, gateOptsFromArgs } from './safety.js';
 import type { BranchDiffStats } from '../types.js';
 
@@ -82,15 +82,9 @@ export function buildAdvancedHandlers(transport: Transport): Record<string, Tool
         const pushed = await transport.pushToRemote(projectPath);
         return textResult({ committed, pushed });
       } catch (e) {
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `已提交但推送失败（需手动 push）。\ncommit: ${JSON.stringify(committed)}\npush error: ${e instanceof Error ? e.message : String(e)}`,
-            },
-          ],
-          isError: true,
-        };
+        return errorResult(
+          `已提交但推送失败（需手动 push）。\ncommit: ${JSON.stringify(committed)}\npush error: ${e instanceof Error ? e.message : String(e)}`
+        );
       }
     },
 
@@ -106,7 +100,7 @@ export function buildAdvancedHandlers(transport: Transport): Record<string, Tool
         { ahead: stats.ahead_of_test, changed_files: stats.changed_files },
         gateOptsFromArgs(args)
       );
-      if (!gate.allow) return { content: [{ type: 'text', text: `合并到 test 被拦截：${gate.reason}` }], isError: true };
+      if (!gate.allow) return errorResult(`合并到 test 被拦截：${gate.reason}`);
       return textResult(await transport.mergeToTest(projectPath, testBranch));
     },
 
@@ -119,7 +113,7 @@ export function buildAdvancedHandlers(transport: Transport): Record<string, Tool
         { ahead: stats.ahead, changed_files: stats.changed_files },
         gateOptsFromArgs(args)
       );
-      if (!gate.allow) return { content: [{ type: 'text', text: `合并到 base 被拦截：${gate.reason}` }], isError: true };
+      if (!gate.allow) return errorResult(`合并到 base 被拦截：${gate.reason}`);
       return textResult(await transport.mergeToBase(projectPath, baseBranch));
     },
   };

--- a/packages/mcp/src/tools/advanced.ts
+++ b/packages/mcp/src/tools/advanced.ts
@@ -48,6 +48,49 @@ export function buildAdvancedHandlers(transport: Transport): Record<string, Tool
       if (!projectPath) throw new Error('project_path is required');
       return textResult(await transport.fetchProjectRemote(projectPath));
     },
+
+    sync_base: async (args) => {
+      const projectPath = args?.project_path as string;
+      const baseBranch = args?.base_branch as string;
+      if (!projectPath || !baseBranch) throw new Error('project_path and base_branch are required');
+      return textResult(await transport.syncWithBase(projectPath, baseBranch));
+    },
+
+    pull: async (args) => {
+      const projectPath = args?.project_path as string;
+      if (!projectPath) throw new Error('project_path is required');
+      return textResult(await transport.pullCurrentBranch(projectPath));
+    },
+
+    push: async (args) => {
+      const projectPath = args?.project_path as string;
+      if (!projectPath) throw new Error('project_path is required');
+      return textResult(await transport.pushToRemote(projectPath));
+    },
+
+    commit_and_push: async (args) => {
+      const projectPath = args?.project_path as string;
+      const message = args?.message as string;
+      if (!projectPath || !message) throw new Error('project_path and message are required');
+      const authorName = args?.author_name as string | undefined;
+      const authorEmail = args?.author_email as string | undefined;
+      const skipHooks = typeof args?.skip_hooks === 'boolean' ? (args.skip_hooks as boolean) : undefined;
+      const committed = await transport.commitAll(projectPath, message, authorName, authorEmail, skipHooks);
+      try {
+        const pushed = await transport.pushToRemote(projectPath);
+        return textResult({ committed, pushed });
+      } catch (e) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `已提交但推送失败（需手动 push）。\ncommit: ${JSON.stringify(committed)}\npush error: ${e instanceof Error ? e.message : String(e)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
   };
 }
 
@@ -141,6 +184,51 @@ export const ADVANCED_TOOLS = [
         project_path: { type: 'string' },
       },
       required: ['project_path'],
+    },
+  },
+  {
+    name: 'sync_base',
+    description: 'Sync the latest base branch into the current branch (fetch origin/base + merge). Requires advanced capability.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        project_path: { type: 'string' },
+        base_branch: { type: 'string' },
+      },
+      required: ['project_path', 'base_branch'],
+    },
+  },
+  {
+    name: 'pull',
+    description: 'git pull the current branch from origin. Requires advanced capability.',
+    inputSchema: {
+      type: 'object',
+      properties: { project_path: { type: 'string' } },
+      required: ['project_path'],
+    },
+  },
+  {
+    name: 'push',
+    description: 'Push the current branch to origin. Requires advanced capability.',
+    inputSchema: {
+      type: 'object',
+      properties: { project_path: { type: 'string' } },
+      required: ['project_path'],
+    },
+  },
+  {
+    name: 'commit_and_push',
+    description: 'Stage all changes, commit with message, then push. Non-atomic: if commit succeeds but push fails, returns isError with a "committed but not pushed" message. Requires advanced capability.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        project_path: { type: 'string' },
+        message: { type: 'string' },
+        author_name: { type: 'string' },
+        author_email: { type: 'string' },
+        skip_hooks: { type: 'boolean' },
+      },
+      required: ['project_path', 'message'],
     },
   },
 ];

--- a/packages/mcp/src/tools/advanced.ts
+++ b/packages/mcp/src/tools/advanced.ts
@@ -1,103 +1,54 @@
-import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import { CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import type { Transport } from '../transport/http.js';
+import { type ToolHandler, textResult } from './shared.js';
 
-export function registerAdvancedTools(
-  server: Server,
-  transport: Transport
-): void {
-  server.setRequestHandler(
-    CallToolRequestSchema,
-    async (request) => {
-      const { name, arguments: args } = request.params;
+export function buildAdvancedHandlers(transport: Transport): Record<string, ToolHandler> {
+  return {
+    worktree_create: async (args) => {
+      const name = args?.name as string;
+      const projects = args?.projects as Array<{ name: string; base_branch?: string }>;
+      const folder_name = args?.folder_name as string | undefined;
+      if (!name || !projects) throw new Error('name and projects are required');
+      return textResult(await transport.createWorktree({ name, projects, folder_name }));
+    },
 
-      if (name === 'worktree_create') {
-        const name = args?.name as string;
-        const projects = args?.projects as Array<{ name: string; base_branch?: string }>;
-        const folder_name = args?.folder_name as string | undefined;
-        if (!name || !projects) {
-          throw new Error('name and projects are required');
-        }
-        const result = await transport.createWorktree({ name, projects, folder_name });
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      }
+    worktree_archive: async (args) => {
+      const name = args?.name as string;
+      if (!name) throw new Error('name is required');
+      return textResult(await transport.archiveWorktree(name));
+    },
 
-      if (name === 'worktree_archive') {
-        const name = args?.name as string;
-        if (!name) {
-          throw new Error('name is required');
-        }
-        const result = await transport.archiveWorktree(name);
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      }
+    worktree_delete_archived: async (args) => {
+      const name = args?.name as string;
+      if (!name) throw new Error('name is required');
+      return textResult(await transport.deleteArchivedWorktree(name));
+    },
 
-      if (name === 'worktree_delete_archived') {
-        const name = args?.name as string;
-        if (!name) {
-          throw new Error('name is required');
-        }
-        const result = await transport.deleteArchivedWorktree(name);
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      }
+    git_commit: async (args) => {
+      const projectPath = args?.project_path as string;
+      const message = args?.message as string;
+      if (!projectPath || !message) throw new Error('project_path and message are required');
+      return textResult(await transport.commitAll(projectPath, message));
+    },
 
-      if (name === 'git_commit') {
-        const projectPath = args?.project_path as string;
-        const message = args?.message as string;
-        if (!projectPath || !message) {
-          throw new Error('project_path and message are required');
-        }
-        const result = await transport.commitAll(projectPath, message);
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      }
+    git_push: async (args) => {
+      const projectPath = args?.project_path as string;
+      if (!projectPath) throw new Error('project_path is required');
+      return textResult(await transport.pushToRemote(projectPath));
+    },
 
-      if (name === 'git_push') {
-        const projectPath = args?.project_path as string;
-        if (!projectPath) {
-          throw new Error('project_path is required');
-        }
-        const result = await transport.pushToRemote(projectPath);
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      }
+    git_switch_branch: async (args) => {
+      const projectPath = args?.project_path as string;
+      const branchName = args?.branch_name as string;
+      if (!projectPath || !branchName) throw new Error('project_path and branch_name are required');
+      return textResult(await transport.switchBranch(projectPath, branchName));
+    },
 
-      if (name === 'git_switch_branch') {
-        const projectPath = args?.project_path as string;
-        const branchName = args?.branch_name as string;
-        if (!projectPath || !branchName) {
-          throw new Error('project_path and branch_name are required');
-        }
-        const result = await transport.switchBranch(projectPath, branchName);
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      }
-
-      if (name === 'git_fetch') {
-        const projectPath = args?.project_path as string;
-        if (!projectPath) {
-          throw new Error('project_path is required');
-        }
-        const result = await transport.fetchProjectRemote(projectPath);
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      }
-
-      return {
-        content: [{ type: 'text', text: `Unknown tool: ${name}` }],
-        isError: true,
-      };
-    }
-  );
+    git_fetch: async (args) => {
+      const projectPath = args?.project_path as string;
+      if (!projectPath) throw new Error('project_path is required');
+      return textResult(await transport.fetchProjectRemote(projectPath));
+    },
+  };
 }
 
 export const ADVANCED_TOOLS = [

--- a/packages/mcp/src/tools/core.ts
+++ b/packages/mcp/src/tools/core.ts
@@ -1,59 +1,23 @@
-import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import { CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import type { BaseTransport } from '../transport/config.js';
+import { type ToolHandler, textResult } from './shared.js';
 
-export function registerCoreTools(server: Server, transport: BaseTransport): void {
-  server.setRequestHandler(
-    CallToolRequestSchema,
-    async (request) => {
-      const { name, arguments: args } = request.params;
+export function buildCoreHandlers(transport: BaseTransport): Record<string, ToolHandler> {
+  return {
+    workspace_list: async () => textResult(await transport.listWorkspaces()),
 
-      if (name === 'workspace_list') {
-        const result = await transport.listWorkspaces();
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      }
+    workspace_get_current: async () => textResult(await transport.getCurrentWorkspace()),
 
-      if (name === 'workspace_get_current') {
-        const result = await transport.getCurrentWorkspace();
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      }
+    worktree_list: async (args) =>
+      textResult(await transport.listWorktrees(args?.include_archived === true)),
 
-      if (name === 'worktree_list') {
-        const includeArchived = args?.include_archived === true;
-        const result = await transport.listWorktrees(includeArchived);
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      }
+    worktree_get_status: async (args) => {
+      const name = args?.name as string;
+      if (!name) throw new Error('worktree name is required');
+      return textResult(await transport.checkWorktreeStatus(name));
+    },
 
-      if (name === 'worktree_get_status') {
-        const name = args?.name as string;
-        if (!name) {
-          throw new Error('worktree name is required');
-        }
-        const status = await transport.checkWorktreeStatus(name);
-        return {
-          content: [{ type: 'text', text: JSON.stringify(status, null, 2) }],
-        };
-      }
-
-      if (name === 'workspace_get_status') {
-        const result = await transport.getMainWorkspaceStatus();
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      }
-
-      return {
-        content: [{ type: 'text', text: `Unknown tool: ${name}` }],
-        isError: true,
-      };
-    }
-  );
+    workspace_get_status: async () => textResult(await transport.getMainWorkspaceStatus()),
+  };
 }
 
 export const CORE_TOOLS = [

--- a/packages/mcp/src/tools/core.ts
+++ b/packages/mcp/src/tools/core.ts
@@ -17,6 +17,30 @@ export function buildCoreHandlers(transport: BaseTransport): Record<string, Tool
     },
 
     workspace_get_status: async () => textResult(await transport.getMainWorkspaceStatus()),
+
+    get_active_workspace: async (args) => {
+      const cwd = args?.cwd as string;
+      if (!cwd) throw new Error('cwd is required');
+      const wsResult = (await transport.listWorkspaces()) as { workspaces?: Array<{ name: string; path: string }> };
+      const workspaces = wsResult?.workspaces ?? [];
+      const norm = (p: string) => p.replace(/\/+$/, '');
+      const inside = (child: string, parent: string) => child === parent || child.startsWith(parent + '/');
+      let best: { name: string; path: string } | null = null;
+      for (const w of workspaces) {
+        const wp = norm(w.path);
+        if (inside(cwd, wp) && (!best || wp.length > norm(best.path).length)) best = w;
+      }
+      if (!best) {
+        return textResult({ workspace: null, worktree_name: null, project_name: null, matched_by: 'prefix' });
+      }
+      const rel = cwd.slice(norm(best.path).length).replace(/^\/+/, '');
+      const segs = rel.split('/').filter(Boolean);
+      const pjIdx = segs.indexOf('projects');
+      const project_name = pjIdx >= 0 && segs.length > pjIdx + 1 ? segs[pjIdx + 1] : null;
+      // 结构 <ws>/<worktrees_dir>/<worktree>/projects/<project> → worktree = projects 前一段；主工作区 <ws>/projects/... 无 worktree
+      const worktree_name = pjIdx >= 2 ? segs[pjIdx - 1] : null;
+      return textResult({ workspace: best, worktree_name, project_name, matched_by: 'prefix' });
+    },
   };
 }
 
@@ -68,6 +92,17 @@ export const CORE_TOOLS = [
     inputSchema: {
       type: 'object',
       properties: {},
+    },
+  },
+  {
+    name: 'get_active_workspace',
+    description: 'Resolve which workspace (and worktree/project, if any) a given absolute directory belongs to, by longest-prefix match against configured workspace paths. Pass the current shell working directory as cwd.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        cwd: { type: 'string', description: 'Absolute path of the current working directory' },
+      },
+      required: ['cwd'],
     },
   },
 ];

--- a/packages/mcp/src/tools/core.ts
+++ b/packages/mcp/src/tools/core.ts
@@ -38,6 +38,8 @@ export function buildCoreHandlers(transport: BaseTransport): Record<string, Tool
       const pjIdx = segs.indexOf('projects');
       const project_name = pjIdx >= 0 && segs.length > pjIdx + 1 ? segs[pjIdx + 1] : null;
       // 结构 <ws>/<worktrees_dir>/<worktree>/projects/<project> → worktree = projects 前一段；主工作区 <ws>/projects/... 无 worktree
+      // 假设标准单层 worktrees_dir 布局；多段 worktrees_dir 时该位置推导可能不准
+      // （list_workspaces 不返回 worktrees_dir 配置，暂按单层处理）。
       const worktree_name = pjIdx >= 2 ? segs[pjIdx - 1] : null;
       return textResult({ workspace: best, worktree_name, project_name, matched_by: 'prefix' });
     },

--- a/packages/mcp/src/tools/details.ts
+++ b/packages/mcp/src/tools/details.ts
@@ -1,56 +1,27 @@
-import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import { CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import type { Transport } from '../transport/http.js';
+import { type ToolHandler, textResult } from './shared.js';
 
-export function registerDetailsTools(
-  server: Server,
-  transport: Transport
-): void {
-  server.setRequestHandler(
-    CallToolRequestSchema,
-    async (request) => {
-      const { name, arguments: args } = request.params;
+export function buildDetailsHandlers(transport: Transport): Record<string, ToolHandler> {
+  return {
+    project_get_branches: async (args) => {
+      const projectPath = args?.project_path as string;
+      if (!projectPath) throw new Error('project_path is required');
+      return textResult(await transport.getRemoteBranches(projectPath));
+    },
 
-      if (name === 'project_get_branches') {
-        const projectPath = args?.project_path as string;
-        if (!projectPath) {
-          throw new Error('project_path is required');
-        }
-        const result = await transport.getRemoteBranches(projectPath);
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      }
+    project_get_diff_stats: async (args) => {
+      const projectPath = args?.project_path as string;
+      const baseBranch = args?.base_branch as string;
+      if (!projectPath || !baseBranch) throw new Error('project_path and base_branch are required');
+      return textResult(await transport.getBranchDiffStats(projectPath, baseBranch));
+    },
 
-      if (name === 'project_get_diff_stats') {
-        const projectPath = args?.project_path as string;
-        const baseBranch = args?.base_branch as string;
-        if (!projectPath || !baseBranch) {
-          throw new Error('project_path and base_branch are required');
-        }
-        const result = await transport.getBranchDiffStats(projectPath, baseBranch);
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      }
-
-      if (name === 'project_get_changed_files') {
-        const projectPath = args?.project_path as string;
-        if (!projectPath) {
-          throw new Error('project_path is required');
-        }
-        const result = await transport.getChangedFiles(projectPath);
-        return {
-          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-        };
-      }
-
-      return {
-        content: [{ type: 'text', text: `Unknown tool: ${name}` }],
-        isError: true,
-      };
-    }
-  );
+    project_get_changed_files: async (args) => {
+      const projectPath = args?.project_path as string;
+      if (!projectPath) throw new Error('project_path is required');
+      return textResult(await transport.getChangedFiles(projectPath));
+    },
+  };
 }
 
 export const DETAILS_TOOLS = [

--- a/packages/mcp/src/tools/details.ts
+++ b/packages/mcp/src/tools/details.ts
@@ -21,6 +21,37 @@ export function buildDetailsHandlers(transport: Transport): Record<string, ToolH
       if (!projectPath) throw new Error('project_path is required');
       return textResult(await transport.getChangedFiles(projectPath));
     },
+
+    list_projects: async (args) => {
+      const worktreeName = args?.worktree_name as string | undefined;
+      const result = (await transport.listWorktrees(false)) as {
+        worktrees?: Array<{ name: string; projects?: Array<Record<string, unknown>> }>;
+      };
+      const worktrees = result?.worktrees ?? [];
+      const filtered = worktreeName ? worktrees.filter((w) => w.name === worktreeName) : worktrees;
+      const projects = filtered.flatMap((w) =>
+        (w.projects ?? []).map((p) => ({
+          worktree: w.name,
+          name: p.name,
+          path: p.path,
+          current_branch: p.current_branch,
+          base_branch: p.base_branch,
+          test_branch: p.test_branch,
+        }))
+      );
+      return textResult(projects);
+    },
+
+    get_branch_status: async (args) => {
+      const projectPath = args?.project_path as string;
+      const baseBranch = args?.base_branch as string;
+      const testBranch = args?.test_branch as string | undefined;
+      const fetchFirst = args?.fetch_first === true;
+      if (!projectPath || !baseBranch) throw new Error('project_path and base_branch are required');
+      if (fetchFirst) await transport.fetchProjectRemote(projectPath);
+      const stats = await transport.getBranchDiffStats(projectPath, baseBranch, testBranch);
+      return textResult(stats);
+    },
   };
 }
 
@@ -60,6 +91,30 @@ export const DETAILS_TOOLS = [
         project_path: { type: 'string', description: 'Full path to the project' },
       },
       required: ['project_path'],
+    },
+  },
+  {
+    name: 'list_projects',
+    description: 'List projects (and their current/base/test branches) in the current workspace, optionally filtered to a single worktree by name.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        worktree_name: { type: 'string', description: 'Optional: only list projects in this worktree' },
+      },
+    },
+  },
+  {
+    name: 'get_branch_status',
+    description: 'Get how far a project branch is ahead/behind base and ahead of test, plus changed-file count. Returns {ahead, behind, changed_files, unpushed_commits, ahead_of_test}. ahead/behind are vs origin/<base_branch>; data is from local refs (pass fetch_first:true to refresh first).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        project_path: { type: 'string', description: 'Absolute path to the project directory' },
+        base_branch: { type: 'string', description: 'Base branch to compare against' },
+        test_branch: { type: 'string', description: 'Optional test branch for ahead_of_test' },
+        fetch_first: { type: 'boolean', description: 'Fetch remote before computing (default false)' },
+      },
+      required: ['project_path', 'base_branch'],
     },
   },
 ];

--- a/packages/mcp/src/tools/safety.test.ts
+++ b/packages/mcp/src/tools/safety.test.ts
@@ -1,0 +1,37 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { evaluateMergeGate, gateOptsFromArgs, DEFAULT_MAX_AHEAD } from './safety.js';
+
+test('allows merge under threshold with clean worktree', () => {
+  const r = evaluateMergeGate({ ahead: 3, changed_files: 0 }, { max_ahead: 50, require_clean_worktree: true, force: false });
+  assert.equal(r.allow, true);
+});
+
+test('blocks when ahead exceeds threshold', () => {
+  const r = evaluateMergeGate({ ahead: 99, changed_files: 0 }, { max_ahead: 50, require_clean_worktree: true, force: false });
+  assert.equal(r.allow, false);
+  assert.match(r.reason ?? '', /阈值/);
+});
+
+test('blocks on dirty worktree when require_clean_worktree', () => {
+  const r = evaluateMergeGate({ ahead: 1, changed_files: 4 }, { max_ahead: 50, require_clean_worktree: true, force: false });
+  assert.equal(r.allow, false);
+  assert.match(r.reason ?? '', /未提交/);
+});
+
+test('force bypasses all gates', () => {
+  const r = evaluateMergeGate({ ahead: 999, changed_files: 9 }, { max_ahead: 50, require_clean_worktree: true, force: true });
+  assert.equal(r.allow, true);
+});
+
+test('gateOptsFromArgs applies defaults', () => {
+  const o = gateOptsFromArgs({});
+  assert.equal(o.max_ahead, DEFAULT_MAX_AHEAD);
+  assert.equal(o.require_clean_worktree, true);
+  assert.equal(o.force, false);
+});
+
+test('gateOptsFromArgs honors overrides', () => {
+  const o = gateOptsFromArgs({ max_ahead: 10, require_clean_worktree: false, force: true });
+  assert.deepEqual(o, { max_ahead: 10, require_clean_worktree: false, force: true });
+});

--- a/packages/mcp/src/tools/safety.test.ts
+++ b/packages/mcp/src/tools/safety.test.ts
@@ -35,3 +35,20 @@ test('gateOptsFromArgs honors overrides', () => {
   const o = gateOptsFromArgs({ max_ahead: 10, require_clean_worktree: false, force: true });
   assert.deepEqual(o, { max_ahead: 10, require_clean_worktree: false, force: true });
 });
+
+test('allows merge exactly at threshold boundary', () => {
+  const r = evaluateMergeGate({ ahead: 50, changed_files: 0 }, { max_ahead: 50, require_clean_worktree: true, force: false });
+  assert.equal(r.allow, true);
+});
+
+test('gateOptsFromArgs honors partial input (only max_ahead)', () => {
+  const o = gateOptsFromArgs({ max_ahead: 10 });
+  assert.equal(o.max_ahead, 10);
+  assert.equal(o.require_clean_worktree, true);
+  assert.equal(o.force, false);
+});
+
+test('gateOptsFromArgs falls back on invalid max_ahead (NaN/negative)', () => {
+  assert.equal(gateOptsFromArgs({ max_ahead: NaN }).max_ahead, DEFAULT_MAX_AHEAD);
+  assert.equal(gateOptsFromArgs({ max_ahead: -1 }).max_ahead, DEFAULT_MAX_AHEAD);
+});

--- a/packages/mcp/src/tools/safety.ts
+++ b/packages/mcp/src/tools/safety.ts
@@ -32,9 +32,10 @@ export function evaluateMergeGate(input: MergeGateInput, opts: MergeGateOpts): M
 
 // 从工具入参解析门控选项
 export function gateOptsFromArgs(args: Record<string, unknown>): MergeGateOpts {
+  const n = args?.max_ahead;
   return {
-    max_ahead: typeof args?.max_ahead === 'number' ? (args.max_ahead as number) : DEFAULT_MAX_AHEAD,
-    require_clean_worktree: args?.require_clean_worktree === false ? false : true,
+    max_ahead: typeof n === 'number' && Number.isFinite(n) && n >= 0 ? n : DEFAULT_MAX_AHEAD,
+    require_clean_worktree: args?.require_clean_worktree !== false,
     force: args?.force === true,
   };
 }

--- a/packages/mcp/src/tools/safety.ts
+++ b/packages/mcp/src/tools/safety.ts
@@ -1,0 +1,40 @@
+import type { MergeGateOpts } from '../types.js';
+
+export const DEFAULT_MAX_AHEAD = 50;
+
+export interface MergeGateInput {
+  ahead: number;          // 领先目标分支的提交数（merge_to_test 用 ahead_of_test，merge_to_base 用 ahead）
+  changed_files: number;  // 工作区未提交变更文件数
+}
+
+export interface MergeGateResult {
+  allow: boolean;
+  reason?: string;
+}
+
+// 纯函数：判断合并是否放行（"数量不大"护栏）
+export function evaluateMergeGate(input: MergeGateInput, opts: MergeGateOpts): MergeGateResult {
+  if (opts.force) return { allow: true };
+  if (opts.require_clean_worktree && input.changed_files > 0) {
+    return {
+      allow: false,
+      reason: `工作区有 ${input.changed_files} 个未提交变更，请先提交或 stash（确属预期可传 force:true 跳过）`,
+    };
+  }
+  if (input.ahead > opts.max_ahead) {
+    return {
+      allow: false,
+      reason: `领先目标分支 ${input.ahead} 个提交，超过阈值 ${opts.max_ahead}，疑似分支选错或需人工确认（确属预期可传 force:true）`,
+    };
+  }
+  return { allow: true };
+}
+
+// 从工具入参解析门控选项
+export function gateOptsFromArgs(args: Record<string, unknown>): MergeGateOpts {
+  return {
+    max_ahead: typeof args?.max_ahead === 'number' ? (args.max_ahead as number) : DEFAULT_MAX_AHEAD,
+    require_clean_worktree: args?.require_clean_worktree === false ? false : true,
+    force: args?.force === true,
+  };
+}

--- a/packages/mcp/src/tools/shared.ts
+++ b/packages/mcp/src/tools/shared.ts
@@ -1,8 +1,7 @@
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+
 // 工具调用返回结构（MCP CallTool 的 content 形态）
-export interface ToolResult {
-  content: Array<{ type: 'text'; text: string }>;
-  isError?: boolean;
-}
+export type ToolResult = CallToolResult;
 
 // 单个工具的处理函数：接收 arguments，返回 ToolResult
 export type ToolHandler = (args: Record<string, unknown>) => Promise<ToolResult>;

--- a/packages/mcp/src/tools/shared.ts
+++ b/packages/mcp/src/tools/shared.ts
@@ -1,0 +1,18 @@
+// 工具调用返回结构（MCP CallTool 的 content 形态）
+export interface ToolResult {
+  content: Array<{ type: 'text'; text: string }>;
+  isError?: boolean;
+}
+
+// 单个工具的处理函数：接收 arguments，返回 ToolResult
+export type ToolHandler = (args: Record<string, unknown>) => Promise<ToolResult>;
+
+// 把任意值包装成文本型 ToolResult
+export function textResult(value: unknown): ToolResult {
+  return { content: [{ type: 'text', text: JSON.stringify(value, null, 2) }] };
+}
+
+// 错误型 ToolResult
+export function errorResult(message: string): ToolResult {
+  return { content: [{ type: 'text', text: message }], isError: true };
+}

--- a/packages/mcp/src/transport/config.ts
+++ b/packages/mcp/src/transport/config.ts
@@ -26,13 +26,24 @@ export interface Transport extends BaseTransport {
   }): Promise<unknown>;
   archiveWorktree(name: string): Promise<unknown>;
   deleteArchivedWorktree(name: string): Promise<unknown>;
-  getBranchDiffStats(projectPath: string, baseBranch: string): Promise<unknown>;
+  getBranchDiffStats(projectPath: string, baseBranch: string, testBranch?: string): Promise<unknown>;
   getChangedFiles(projectPath: string): Promise<unknown>;
   getRemoteBranches(projectPath: string): Promise<unknown>;
-  commitAll(projectPath: string, message: string): Promise<unknown>;
+  commitAll(
+    projectPath: string,
+    message: string,
+    authorName?: string,
+    authorEmail?: string,
+    skipHooks?: boolean
+  ): Promise<unknown>;
   pushToRemote(projectPath: string): Promise<unknown>;
   switchBranch(projectPath: string, branchName: string): Promise<unknown>;
   fetchProjectRemote(projectPath: string): Promise<unknown>;
+  // 新增写/同步方法
+  pullCurrentBranch(projectPath: string): Promise<unknown>;
+  syncWithBase(projectPath: string, baseBranch: string): Promise<unknown>;
+  mergeToTest(projectPath: string, testBranch: string): Promise<unknown>;
+  mergeToBase(projectPath: string, baseBranch: string): Promise<unknown>;
 }
 
 export class ConfigTransport implements BaseTransport {

--- a/packages/mcp/src/transport/http.ts
+++ b/packages/mcp/src/transport/http.ts
@@ -3,6 +3,7 @@ import type { TransportMode } from '../types.js';
 import type { Transport } from './config.js';
 
 const DEFAULT_PORT = 42819;
+const WRITE_TIMEOUT = 60000; // 写/网络操作（merge/push/pull/sync/commit）用更长超时
 
 export { Transport } from './config.js';
 
@@ -86,11 +87,10 @@ export class HttpTransport implements Transport {
   }
 
   // Project/Git operations
-  async getBranchDiffStats(projectPath: string, baseBranch: string): Promise<unknown> {
-    const res = await this.client.post('/get_branch_diff_stats', {
-      path: projectPath,
-      base_branch: baseBranch,
-    });
+  async getBranchDiffStats(projectPath: string, baseBranch: string, testBranch?: string): Promise<unknown> {
+    const body: Record<string, unknown> = { path: projectPath, base_branch: baseBranch };
+    if (testBranch) body.test_branch = testBranch;
+    const res = await this.client.post('/get_branch_diff_stats', body);
     return res.data;
   }
 
@@ -104,13 +104,23 @@ export class HttpTransport implements Transport {
     return res.data;
   }
 
-  async commitAll(projectPath: string, message: string): Promise<unknown> {
-    const res = await this.client.post('/commit_all', { path: projectPath, message });
+  async commitAll(
+    projectPath: string,
+    message: string,
+    authorName?: string,
+    authorEmail?: string,
+    skipHooks?: boolean
+  ): Promise<unknown> {
+    const body: Record<string, unknown> = { path: projectPath, message };
+    if (authorName) body.author_name = authorName;
+    if (authorEmail) body.author_email = authorEmail;
+    if (typeof skipHooks === 'boolean') body.skip_hooks = skipHooks;
+    const res = await this.client.post('/commit_all', body, { timeout: WRITE_TIMEOUT });
     return res.data;
   }
 
   async pushToRemote(projectPath: string): Promise<unknown> {
-    const res = await this.client.post('/push_to_remote', { path: projectPath });
+    const res = await this.client.post('/push_to_remote', { path: projectPath }, { timeout: WRITE_TIMEOUT });
     return res.data;
   }
 
@@ -121,6 +131,38 @@ export class HttpTransport implements Transport {
 
   async fetchProjectRemote(projectPath: string): Promise<unknown> {
     const res = await this.client.post('/fetch_project_remote', { path: projectPath });
+    return res.data;
+  }
+
+  async pullCurrentBranch(projectPath: string): Promise<unknown> {
+    const res = await this.client.post('/pull_current_branch', { path: projectPath }, { timeout: WRITE_TIMEOUT });
+    return res.data;
+  }
+
+  async syncWithBase(projectPath: string, baseBranch: string): Promise<unknown> {
+    const res = await this.client.post(
+      '/sync_with_base_branch',
+      { path: projectPath, base_branch: baseBranch },
+      { timeout: WRITE_TIMEOUT }
+    );
+    return res.data;
+  }
+
+  async mergeToTest(projectPath: string, testBranch: string): Promise<unknown> {
+    const res = await this.client.post(
+      '/merge_to_test_branch',
+      { path: projectPath, test_branch: testBranch },
+      { timeout: WRITE_TIMEOUT }
+    );
+    return res.data;
+  }
+
+  async mergeToBase(projectPath: string, baseBranch: string): Promise<unknown> {
+    const res = await this.client.post(
+      '/merge_to_base_branch',
+      { path: projectPath, base_branch: baseBranch },
+      { timeout: WRITE_TIMEOUT }
+    );
     return res.data;
   }
 }

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -28,11 +28,28 @@ export interface ProjectStatus {
   behind_base: number;
 }
 
-// Branch diff stats
+// Branch diff stats（对齐后端 git_ops.rs BranchDiffStats）
 export interface BranchDiffStats {
-  ahead: number;
-  behind: number;
-  changed_files: number;
+  ahead: number;            // 领先 base 的提交数
+  behind: number;           // 落后 base 的提交数
+  changed_files: number;    // 工作区变更文件数
+  unpushed_commits: number; // 未推送提交数
+  ahead_of_test: number;    // 领先 test 的提交数
+}
+
+// get_active_workspace 返回
+export interface ActiveWorkspaceResult {
+  workspace: WorkspaceRef | null;
+  worktree_name: string | null;
+  project_name: string | null;
+  matched_by: 'prefix';
+}
+
+// 合并阈值门控参数
+export interface MergeGateOpts {
+  max_ahead: number;
+  require_clean_worktree: boolean;
+  force: boolean;
 }
 
 // Changed file

--- a/src-tauri/src/commands/sharing.rs
+++ b/src-tauri/src/commands/sharing.rs
@@ -82,10 +82,7 @@ pub async fn start_sharing_internal(
             "[sharing] Rejected: port {} conflicts with MCP server",
             port
         );
-        return Err(format!(
-            "端口 {} 已被 MCP 服务占用，请更换其他端口",
-            port
-        ));
+        return Err(format!("端口 {} 已被 MCP 服务占用，请更换其他端口", port));
     }
 
     // Check if already sharing

--- a/src-tauri/src/http_server.rs
+++ b/src-tauri/src/http_server.rs
@@ -3150,12 +3150,16 @@ pub fn save_mcp_config(config: &McpConfig) -> Result<(), String> {
 pub async fn start_mcp_server(port: u16) -> Result<(), String> {
     let addr = SocketAddr::from(([127, 0, 0, 1], port));
 
-    // Save MCP config
+    // Save MCP config（保留已有 capability_level，缺省 details；不覆盖用户设置）
+    let capability_level = load_mcp_config()
+        .map(|c| c.capability_level)
+        .filter(|l| matches!(l.as_str(), "core" | "details" | "advanced"))
+        .unwrap_or_else(|| "details".to_string());
     let config = McpConfig {
         version: env!("CARGO_PKG_VERSION").to_string(),
         http_port: port,
         installed_at: chrono::Utc::now().to_rfc3339(),
-        capability_level: "core".to_string(),
+        capability_level,
     };
     save_mcp_config(&config)?;
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,9 @@ export default defineConfig({
     environment: "jsdom",
     setupFiles: ["./src/test/setup.ts"],
     css: false,
+    // packages/* are standalone packages with their own test runners
+    // (e.g. packages/mcp uses node:test); keep them out of the root vitest run.
+    exclude: ["**/node_modules/**", "**/dist/**", "packages/**"],
   },
   resolve: {
     alias: { "@": path.resolve(__dirname, "./src") },


### PR DESCRIPTION
## Overview

Expands the MCP server toolset and fixes two P0 framework bugs.

- **P0 fixes:** single `CallTool` dispatcher with an aggregated handler map; capability level is now read from `mcp.json` (default `details` instead of `core`).
- **9 new tools:**
  - Read: `get_active_workspace`, `list_projects`, `get_branch_status`
  - Write: `sync_base`, `pull`, `push`, `commit_and_push`, `merge_to_test`, `merge_to_base`
- **Merge threshold gate:** `merge_to_test` / `merge_to_base` are guarded by an ahead-count threshold (`evaluateMergeGate`), with hardened input validation and `errorResult` handling.
- Backend `start_mcp_server` now preserves an existing user-set `capability_level` (defaulting to `details`) instead of overwriting it with `core`.
- Transport extended with merge/sync/pull, test_branch diff, and write-operation timeouts.
- Root vitest now excludes `packages/**` (MCP uses `node:test`, not vitest).

## Trust boundary

The MCP HTTP server binds to `127.0.0.1:42819` only and has **no token auth** — the trust boundary is loopback-only (any local process can call it). Documented in `packages/mcp/README.md`.

## Verification

- `cargo check` ✓, `cargo clippy -- -D warnings` ✓
- `cd packages/mcp && npm test` ✓ (9 passed)
- `npm run build` ✓, `node scripts/check-i18n.mjs` ✓ (798 keys), `npm run contracts` ✓ (in sync), `npx vitest run` ✓ (74 passed)

## Known pre-existing bug (not introduced here)

- `git_switch_branch` payload shape does not match the backend handler — out of scope for this PR.

## Plan

`docs/superpowers/plans/2026-06-20-mcp-expand-tools.md`
