### PR TITLE
Fix lucide UMD icon rendering for v0.462.0

### DIFF
--- a/designs/_ds_bundle.js
+++ b/designs/_ds_bundle.js
@@ -590,6 +590,8 @@ function Icon({
   if (ready && window.lucide.icons) {
     node = window.lucide.icons[toPascal(name)] || window.lucide.icons[name] || null;
   }
+  // lucide UMD (0.462.0) icons are a full ['svg', attrs, children] triple — render only the children
+  const entries = Array.isArray(node) && node[0] === 'svg' ? node[2] : node;
   return /*#__PURE__*/React.createElement("svg", _extends({
     xmlns: "http://www.w3.org/2000/svg",
     width: size,
@@ -605,7 +607,7 @@ function Icon({
       flexShrink: 0,
       ...style
     }
-  }, props), Array.isArray(node) ? node.map((n, i) => renderNode(n, i)) : null);
+  }, props), Array.isArray(entries) ? entries.map((n, i) => renderNode(n, i)) : null);
 }
 Object.assign(__ds_scope, { Icon });
 })(); } catch (e) { __ds_ns.__errors.push({ path: "components/icons/Icon.jsx", error: String((e && e.message) || e) }); }

--- a/designs/components/icons/Icon.jsx
+++ b/designs/components/icons/Icon.jsx
@@ -62,6 +62,8 @@ export function Icon({ name, size = 16, strokeWidth = 2, color = 'currentColor',
   if (ready && window.lucide.icons) {
     node = window.lucide.icons[toPascal(name)] || window.lucide.icons[name] || null;
   }
+  // lucide UMD (0.462.0) icons are a full ['svg', attrs, children] triple — render only the children
+  const entries = Array.isArray(node) && node[0] === 'svg' ? node[2] : node;
 
   return (
     <svg
@@ -78,7 +80,7 @@ export function Icon({ name, size = 16, strokeWidth = 2, color = 'currentColor',
       style={{ flexShrink: 0, ...style }}
       {...props}
     >
-      {Array.isArray(node) ? node.map((n, i) => renderNode(n, i)) : null}
+      {Array.isArray(entries) ? entries.map((n, i) => renderNode(n, i)) : null}
     </svg>
   );
 }


### PR DESCRIPTION
## Summary
Updates the Icon component to correctly handle lucide UMD v0.462.0 format, which exports icons as full `['svg', attrs, children]` triples instead of just the children array.

## Changes
- Added detection logic to identify when `node` is a lucide UMD triple (array starting with 'svg')
- Extract only the children portion (`node[2]`) for rendering when the triple format is detected
- Updated both source (`Icon.jsx`) and compiled (`_ds_bundle.js`) versions to use the extracted `entries` variable for rendering

## Implementation Details
The lucide UMD format changed in v0.462.0 to export complete SVG element triples. The fix:
1. Checks if `node` is an array with first element `'svg'` (indicating the new format)
2. Extracts `node[2]` (the children array) when detected, otherwise uses `node` as-is
3. Maintains backward compatibility with any other icon formats by falling back to the original `node` value

https://claude.ai/code/session_018yhDiUrHvyrJuQRXnfgUMx