### PR TITLE
修复 Release 构建：用 npm ci 替代删除锁文件后的 npm install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,12 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ~/.npm
-          key: npm-${{ runner.os }}-${{ hashFiles('package.json') }}
+          key: npm-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
           restore-keys: npm-${{ runner.os }}-
 
+      # npm ci：锁文件即事实来源，与 package.json 不同步时立刻失败（release 同此）。
       - name: Install frontend dependencies
-        run: npm install
+        run: npm ci
 
       - name: Typecheck
         run: npx tsc --noEmit
@@ -106,8 +107,9 @@ jobs:
         with:
           node-version: '22'
 
+      # npm ci：锁文件即事实来源，与 package.json 不同步时立刻失败（release 同此）。
       - name: Install frontend dependencies
-        run: npm install
+        run: npm ci
 
       - name: Build frontend assets
         run: npm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,14 +208,15 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ~/.npm
-          key: npm-${{ runner.os }}-${{ hashFiles('package.json') }}
+          key: npm-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
           restore-keys: npm-${{ runner.os }}-
 
+      # 必须用 npm ci（依赖锁文件）：删掉 package-lock.json 后的全新解析会踩到 npm 的
+      # arborist bug（vitest 的 peer 依赖链 → "Cannot read properties of null (reading
+      # 'edgesOut')"），三个平台都会失败。锁文件已记录各平台的原生可选依赖
+      # （esbuild / rollup / lightningcss 的 win32、darwin 包），跨平台安装无碍。
       - name: Install frontend dependencies
-        shell: bash
-        run: |
-          rm -rf node_modules package-lock.json
-          npm install
+        run: npm ci
 
       - name: Build Tauri App (macOS)
         if: runner.os == 'macOS'


### PR DESCRIPTION
## 问题

main 上的 Release Build（run [33644165715](https://github.com/guoyongchang/worktree-manager/actions/runs/33644165715)）三个平台全部在 `Install frontend dependencies` 这一步失败：

```
npm error Cannot read properties of null (reading 'edgesOut')
    at #loadPeerSet (@npmcli/arborist/lib/arborist/build-ideal-tree.js:1289)
```

后果：`v0.20260902.144555` 这个 Release 被创建但**没有任何安装包**（`assets: []`），`assemble-latest-json` 被跳过，因此更新端点 `releases/latest/download/latest.json` 现在 404 —— 所有已安装用户的应用内更新检查都会失败。

## 根因

release.yml 的这一步会先删掉锁文件再全新解析：

```yaml
rm -rf node_modules package-lock.json
npm install
```

无锁文件的解析路径会走到 npm arborist 解析 `vitest` peer 依赖链（`vitest@*` → `@vitest/browser-playwright` → `jsdom` → `canvas`）时崩溃。

**不是本次改动引入的**：在合并前的 `3393ce9` 上执行同样的命令同样崩溃，只是 registry 侧 vitest 新版本的 peer 链最近才触发这个 npm bug。有锁文件时（CI 工作流）完全正常，所以 CI 是绿的、只有 release 挂。

## 改动

- `release.yml`、`ci.yml`（两处）：改用 `npm ci`，不再删除锁文件。
- npm 缓存 key 由 `package.json` 改为 `package-lock.json`。

两个已验证的关键点：

1. **跨平台原生依赖**：锁文件已记录各平台可选二进制（win32 16 个、darwin 13 个，含 `@rollup/rollup-win32-x64-msvc`、`@esbuild/win32-x64`、`lightningcss-*`）。`npm ci --os=win32 --cpu=x64` 实测装出正确的 Windows 包。
2. **release 的版本改写**：`Set version` 会把 `package.json` 的 version 改成 `0.2026xxxx`，与锁文件根版本不一致。实测 `npm ci` 只校验依赖树、不校验根包 version，安装照常成功。

附带好处：`npm ci` 在锁文件与 `package.json` 漂移时会直接失败，作为门禁比 `npm install` 更可靠。

## 验证

在本 commit 上从干净安装跑通：`npm ci`（422 包）、`npx tsc --noEmit`、`npm run build`、`vitest`（22 文件 / 107 测试）、`check-i18n`、`verify:contracts`，全部通过；另外单独验证了 `npm ci --os=win32 --cpu=x64`。三个 workflow 的 YAML 解析正常。

## 合并后需要处理

合并会触发新的 Release Build，新版本成为 `latest`，更新端点随之恢复。空的 `v0.20260902.144555` release 和 tag 建议手动删除（我没有动它）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018cgwuZYLkisRYHGcAytvQL

---
_Generated by [Claude Code](https://claude.ai/code/session_018cgwuZYLkisRYHGcAytvQL)_